### PR TITLE
Changes to Seeder creation and faker field generation for created_at and updated_at

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,4 @@ phpunit.phar
 .php-cs-fixer.cache
 
 /.vscode
+/.idea

--- a/src/SeederController.php
+++ b/src/SeederController.php
@@ -347,7 +347,7 @@ class SeederController extends Controller
     protected function getDefaultSeeder()
     {
         $defaultSeederClass = "{$this->seederNamespace}\\{$this->defaultSeederClass}";
-        $defaultSeederFile = str_replace('\\', DIRECTORY_SEPARATOR, "{$defaultSeederClass}.php");
+        $defaultSeederFile = "{$this->seederPath}/{$defaultSeederClass}.php";
 
         if (!class_exists($defaultSeederClass) || !file_exists($defaultSeederFile)) {
             FileHelper::createDirectory($this->seederPath);

--- a/src/SeederController.php
+++ b/src/SeederController.php
@@ -6,6 +6,7 @@ use Yii;
 use yii\console\Controller;
 use yii\console\ExitCode;
 use yii\db\ColumnSchema;
+use yii\db\Schema;
 use yii\helpers\ArrayHelper;
 use yii\helpers\Console;
 use yii\helpers\FileHelper;
@@ -278,7 +279,7 @@ class SeederController extends Controller
                 $ref_table_id = $foreign->tableSchema->primaryKey[0];
             }
 
-            $faker = $this->generateFakerField($data->name) ?? $this->generateFakerField($data->type);
+            $faker = $this->generateFakerField($data->name, $data->type) ?? $this->generateFakerField($data->type);
             if ($data->dbType === 'tinyint(1)') {
                 $faker = 'boolean';
             }
@@ -297,9 +298,10 @@ class SeederController extends Controller
      * Generate Faker Field Name
      *
      * @param string $key
+     * @param string|null $dataType The data type of the column schema
      * @return string
      */
-    protected function generateFakerField($key)
+    protected function generateFakerField($key, $dataType = null)
     {
         $faker = [
             'full_name' => 'name',
@@ -316,8 +318,8 @@ class SeederController extends Controller
             'hp' => 'phoneNumber',
             'start_date' => 'dateTime()->format("Y-m-d H:i:s")',
             'end_date' => 'dateTime()->format("Y-m-d H:i:s")',
-            'created_at' => 'dateTime()->format("Y-m-d H:i:s")',
-            'updated_at' => 'dateTime()->format("Y-m-d H:i:s")',
+            'created_at' => $dataType === Schema::TYPE_INTEGER ? 'dateTime()->getTimestamp()' : 'dateTime()->format("Y-m-d H:i:s")',
+            'updated_at' => $dataType === Schema::TYPE_INTEGER ? 'dateTime()->getTimestamp()' : 'dateTime()->format("Y-m-d H:i:s")',
             'token' => 'uuid',
             'duration' => 'numberBetween()',
 


### PR DESCRIPTION
I made the following changes:

1. Added JetBrains IDE files to `.gitignore`.
2. In `SeederController`:
  1. On faker field generation, for `created_at` and `updated_at` fields it checks for the column type so that in case they are integer it'll create a timestamp instead.
  2. When creating the default Seeder in `getDefaultSeeder()`, instead of getting the base path from namespace, it now uses the `seederPath` parameter.

I haven't tested 2.1 to check the previous behavior still works (so for fields that are datetime) since we don't have any cases like that in our repos. Let me know if you want me to test it.

Same for 2.2, I only tested it on basic template applications, but I think it'll work on advanced as well since it's already using the `seederPath` to generate the directory in which to put the file. Without this change, the Seeder creation won't work with basic template.